### PR TITLE
zf3 zf2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,9 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
-        - SERVICE_MANAGER_V2=TRUE
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
-        - SERVICE_MANAGER_V2=TRUE
     - php: 7
     - php: hhvm 
   allow_failures:
@@ -35,8 +33,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+        - SERVICE_MANAGER_V2=TRUE
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+        - SERVICE_MANAGER_V2=TRUE
     - php: 7
     - php: hhvm 
   allow_failures:
@@ -33,6 +35,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-filter": "dev-develop as 2.6.0",
-        "zendframework/zend-validator": "dev-develop",
+        "zendframework/zend-validator": "dev-develop as 2.5.3",
         "zendframework/zend-stdlib": "dev-develop as 2.8.0"
     },
     "require-dev": {
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "^4.5"
     },

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -118,14 +118,7 @@ class Factory
     public function setInputFilterManager(InputFilterPluginManager $inputFilterManager)
     {
         $this->inputFilterManager = $inputFilterManager;
-        if ($inputFilterManager && $inputFilterManager instanceof ServiceLocatorInterface) {
-            if ($inputFilterManager->has('ValidatorManager')) {
-                $this->getDefaultValidatorChain()->setPluginManager($inputFilterManager->get('ValidatorManager'));
-            }
-            if ($inputFilterManager->has('FilterManager')) {
-                $this->getDefaultFilterChain()->setPluginManager($inputFilterManager->get('FilterManager'));
-            }
-        }
+        $inputFilterManager->populateFactoryPluginManagers($this);
         return $this;
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,9 +10,8 @@
 namespace Zend\InputFilter;
 
 use Traversable;
-use Zend\ServiceManager\ServiceManager;
 use Zend\Filter\FilterChain;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorChain;
 use Zend\Validator\ValidatorInterface;

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -9,11 +9,11 @@
 
 namespace Zend\InputFilter;
 
+use Interop\Container\ContainerInterface;
 use Zend\Filter\FilterPluginManager;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\ServiceManager;
-use Interop\Container\ContainerInterface;
 use Zend\Validator\ValidatorPluginManager;
 
 class InputFilterAbstractServiceFactory implements AbstractFactoryInterface

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -31,6 +31,10 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
      */
     public function canCreate(ContainerInterface $services, $rName)
     {
+        if (! $services->has('Config')) {
+            return false;
+        }
+
         $config = $services->get('Config');
         if (!isset($config['input_filter_specs'][$rName])
             || !is_array($config['input_filter_specs'][$rName])
@@ -55,6 +59,17 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
         $factory   = $this->getInputFilterFactory($services);
 
         return $factory->createInputFilter($config);
+    }
+
+    /**
+     * @param ServiceLocatorInterface $inputFilters
+     * @param string                  $cName
+     * @param string                  $rName
+     * @return InputFilterInterface
+     */
+    public function createServiceWithName(ServiceLocatorInterface $inputFilters, $cName, $rName)
+    {
+        return $this($inputFilters, $rName);
     }
 
     /**

--- a/src/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilterAbstractServiceFactory.php
@@ -11,7 +11,7 @@ namespace Zend\InputFilter;
 
 use Interop\Container\ContainerInterface;
 use Zend\Filter\FilterPluginManager;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorPluginManager;
@@ -24,7 +24,8 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     protected $factory;
 
     /**
-     * @param ServiceLocatorInterface $inputFilters
+     *
+     * @param ContainerInterface $services
      * @param string                  $cName
      * @param string                  $rName
      * @return bool
@@ -46,9 +47,22 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * @param ServiceLocatorInterface $inputFilters
-     * @param string                  $cName
+     * Determine if we can create a service with name (v2)
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param $name
+     * @param $requestedName
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return $this->canCreate($serviceLocator, $requestedName);
+    }
+
+    /**
+     * @param ContainerInterface      $services
      * @param string                  $rName
+     * @param array                   $options
      * @return InputFilterInterface
      */
     public function __invoke(ContainerInterface $services, $rName, array  $options = null)

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -93,10 +93,10 @@ class InputFilterPluginManager extends AbstractPluginManager
             $container = $this->serviceLocator;
         }
 
-        if ($container->has('FilterManager')) {
+        if ($container && $container->has('FilterManager')) {
             $factory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
         }
-        if ($container->has('ValidatorManager')) {
+        if ($container && $container->has('ValidatorManager')) {
             $factory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
         }
     }

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -11,11 +11,8 @@ namespace Zend\InputFilter;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\ConfigInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Stdlib\InitializableInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\Stdlib\InitializableInterface;
 
 /**
  * Plugin manager implementation for input filters.

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -85,16 +85,24 @@ class InputFilterPluginManager extends AbstractPluginManager
 
     public function populateFactoryPluginManagers(Factory $factory)
     {
-        if ($this->creationContext->has('FilterManager')) {
-            $factory->getDefaultFilterChain()->setPluginManager($this->creationContext->get('FilterManager'));
+        if (property_exists($this, 'creationContext')) {
+            // v3
+            $container = $this->creationContext;
+        } else {
+            // v2
+            $container = $this->serviceLocator;
         }
-        if ($this->creationContext->has('ValidatorManager')) {
-            $factory->getDefaultValidatorChain()->setPluginManager($this->creationContext->get('ValidatorManager'));
+
+        if ($container->has('FilterManager')) {
+            $factory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
+        }
+        if ($container->has('ValidatorManager')) {
+            $factory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
         }
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc} (v3)
      */
     public function validate($plugin)
     {
@@ -114,6 +122,21 @@ class InputFilterPluginManager extends AbstractPluginManager
             InputFilterInterface::class,
             InputInterface::class
         ));
+    }
+
+    /**
+     * Validate the plugin (v2)
+     *
+     * Checks that the filter loaded is either a valid callback or an instance
+     * of FilterInterface.
+     *
+     * @param  mixed                      $plugin
+     * @return void
+     * @throws Exception\RuntimeException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        $this->validate($plugin);
     }
 
     public function shareByDefault()

--- a/src/InputFilterPluginManager.php
+++ b/src/InputFilterPluginManager.php
@@ -31,7 +31,10 @@ class InputFilterPluginManager extends AbstractPluginManager
      */
     protected $aliases = [
         'inputfilter' => InputFilter::class,
+        'inputFilter' => InputFilter::class,
+        'InputFilter' => InputFilter::class,
         'collection'  => CollectionInputFilter::class,
+        'Collection'  => CollectionInputFilter::class,
     ];
 
     /**
@@ -80,11 +83,16 @@ class InputFilterPluginManager extends AbstractPluginManager
             $factory = $inputFilter->getFactory();
 
             $factory->setInputFilterManager($this);
+        }
+    }
 
-            if ($container instanceof ContainerInterface) {
-                $factory->getDefaultFilterChain()->setPluginManager($container->get('FilterManager'));
-                $factory->getDefaultValidatorChain()->setPluginManager($container->get('ValidatorManager'));
-            }
+    public function populateFactoryPluginManagers(Factory $factory)
+    {
+        if ($this->creationContext->has('FilterManager')) {
+            $factory->getDefaultFilterChain()->setPluginManager($this->creationContext->get('FilterManager'));
+        }
+        if ($this->creationContext->has('ValidatorManager')) {
+            $factory->getDefaultValidatorChain()->setPluginManager($this->creationContext->get('ValidatorManager'));
         }
     }
 
@@ -113,6 +121,6 @@ class InputFilterPluginManager extends AbstractPluginManager
 
     public function shareByDefault()
     {
-        return $this->shareByDefault;
+        return $this->sharedByDefault;
     }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -9,10 +9,10 @@
 
 namespace ZendTest\InputFilter;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter;
-use Interop\Container\ContainerInterface;
 use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Exception\InvalidArgumentException;
 use Zend\InputFilter\Exception\RuntimeException;

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Filter\FilterPluginManager;
 use Zend\InputFilter\InputFilterAbstractServiceFactory;

--- a/test/InputFilterAbstractServiceFactoryTest.php
+++ b/test/InputFilterAbstractServiceFactoryTest.php
@@ -59,7 +59,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->services->setService('Config', [
             'input_filter_specs' => [],
         ]);
-        $this->assertFalse($this->factory->canCreate($this->filters, 'filter'));
+        $this->assertFalse($this->factory->canCreate($this->services, 'filter'));
     }
 
     public function testCanCreateServiceIfConfigInputFiltersContainsMatchingServiceName()
@@ -69,7 +69,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 'filter' => [],
             ],
         ]);
-        $this->assertTrue($this->factory->canCreate($this->filters, 'filter'));
+        $this->assertTrue($this->factory->canCreate($this->services, 'filter'));
     }
 
     public function testCreatesInputFilterInstance()
@@ -88,12 +88,12 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
      */
     public function testUsesConfiguredValidationAndFilterManagerServicesWhenCreatingInputFilter()
     {
-        $filters = new FilterPluginManager();
+        $filters = new FilterPluginManager($this->services);
         $filter  = function ($value) {
         };
         $filters->setService('foo', $filter);
 
-        $validators = new ValidatorPluginManager();
+        $validators = new ValidatorPluginManager($this->services);
         /** @var ValidatorInterface|MockObject $validator */
         $validator  = $this->getMock(ValidatorInterface::class);
         $validators->setService('foo', $validator);
@@ -117,7 +117,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
             ],
         ]);
 
-        $inputFilter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
+        $inputFilter = $this->factory->createServiceWithName($this->services, 'filter', 'filter');
         $this->assertTrue($inputFilter->has('input'));
 
         $input = $inputFilter->get('input');
@@ -128,7 +128,7 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
         $this->assertSame($filter, $filterChain->plugin('foo'));
         $this->assertEquals(1, count($filterChain));
 
-        $validatorChain = $input->getvalidatorChain();
+        $validatorChain = $input->getValidatorChain();
         $this->assertSame($validators, $validatorChain->getPluginManager());
         $this->assertEquals(1, count($validatorChain));
         $this->assertSame($validator, $validatorChain->plugin('foo'));

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -17,9 +17,9 @@ use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\InputFilter\InputInterface;
-use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\InitializableInterface;
 use Zend\Validator\ValidatorPluginManager;
 

--- a/test/InputFilterPluginManagerTest.php
+++ b/test/InputFilterPluginManagerTest.php
@@ -33,9 +33,15 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     protected $manager;
 
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
     public function setUp()
     {
-        $this->manager = new InputFilterPluginManager(new ServiceManager());
+        $this->services = new ServiceManager();
+        $this->manager = new InputFilterPluginManager($this->services);
     }
 
     public function testIsASubclassOfAbstractPluginManager()
@@ -105,15 +111,8 @@ class InputFilterPluginManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $serviceLocator = $this->createServiceLocatorInterfaceMock();
-        $serviceLocator->method('get')
-            ->willReturnMap(
-                [
-                    ['FilterManager', $filterManager],
-                    ['ValidatorManager', $validatorManager],
-                ]
-            )
-        ;
+        $this->services->setService('FilterManager', $filterManager);
+        $this->services->setService('ValidatorManager', $validatorManager);
 
         /** @var InputFilter $service */
         $service = $this->manager->get('inputfilter');


### PR DESCRIPTION
OK, v3 tests are all passing when using a patched ServiceManager. Under v2 there are BC problems with zend-filter and zend-validator that are killing the tests. Not much I can do about that right now.

Previously there was code duplicated between `InputFilterManager::populateFactory()` and `Factory::setInputManager()`. Both needed changing. I've added `InputFilterManager::populateFactoryPluginManagers()` so there's only one place for it to go wrong.